### PR TITLE
Set `npm-programmatic.install` buffer size to 2Mb.

### DIFF
--- a/lib/packExternalModules.js
+++ b/lib/packExternalModules.js
@@ -94,14 +94,16 @@ module.exports = {
       this.serverless.cli.log('Packing external modules: ' + prodModules.join(", "));
 
       const tmpPackageJson = path.join(this.serverless.config.servicePath, 'package.json');
-    
+
       // create a temp package.json in dist directory so that we can install the dependencies later.
       fs.writeFileSync(tmpPackageJson, "{}");
 
+      const OUTPUT_BUFER_SIZE_KB = 2048 * 1024; // 2k * 1024 bytes/kb = 2Mb
       return new BbPromise((resolve, reject) => {
         npm.install(prodModules, {
           cwd: this.serverless.config.servicePath,
-          save: true
+          save: true,
+          maxBuffer: OUTPUT_BUFER_SIZE_KB
         }).then(() => {
           // fs.unlink(tmpPackageJson);
           resolve()


### PR DESCRIPTION
Pretty self-descriptive.